### PR TITLE
Encode the outgoing request to utf-8 to avoid sending unicode escape sequences to API

### DIFF
--- a/pythonzimbra/communication.py
+++ b/pythonzimbra/communication.py
@@ -103,7 +103,7 @@ class Communication(object):
 
             server_request = urllib2.urlopen(
                 self.url,
-                request.get_request(),
+                request.get_request().encode('utf-8'),
                 self.timeout
             )
 


### PR DESCRIPTION
... Cause that does not work and causes parsing errors.

I don't know exactly how to integrate this into the tests, feel free either to do it or to give me hints on how you would do it.