### PR TITLE
Bugfix for handling of lists when creating xml

### DIFF
--- a/pythonzimbra/tools/xmlserializer.py
+++ b/pythonzimbra/tools/xmlserializer.py
@@ -59,13 +59,13 @@ def dict_to_dom(root_node, xml_dict):
 
         elif type(value) == list:
 
-            for multinode in value:
+            tmp_node = root_node.ownerDocument.createElement(key)
 
-                tmp_node = root_node.ownerDocument.createElement(key)
+            for multinode in value:
 
                 dict_to_dom(tmp_node, multinode)
 
-                root_node.appendChild(tmp_node)
+            root_node.appendChild(tmp_node)
 
         else:
 


### PR DESCRIPTION
Hey,
the `dict_to_dom()` method does not correctly handle Python lists. Instead of creating one root element and the sub-elements in it, the root element is repeated for each sub-element.

Example dict:
```
{
    "a": [
        {
            "b": {
                "id": 1
            }
        },
        {
            "b": {
                "id": 2
            }
        }
    ]
}
```
Actual result:
```
<a>
  <b id="1"/>
</a>
<a>
  <b id="2"/>
</a>
```

Expected result:
```
<a>
  <b id="1"/>
  <b id="2"/>
</a>
```

This pull request ought to fix this.
Thanks.